### PR TITLE
Basic Pawn movement

### DIFF
--- a/app/src/main/java/com/projectthrive/chess/ui/main/GameEngine.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/GameEngine.kt
@@ -1,5 +1,7 @@
 package com.projectthrive.chess.ui.main
 
+import com.projectthrive.chess.ui.main.GameViewModel.Companion.selectedPieceViewModel
+
 class GameEngine {
     private val boardState = mutableMapOf<Position, PieceViewModel>()
 
@@ -11,10 +13,20 @@ class GameEngine {
 
     fun getHighlightedPositions(position: Position): List<Position> {
         if (boardState[position] == null) {
+            selectedPieceViewModel.postValue(null)
             return emptyList()
         }
 
-        return listOf(position.copy(x = position.x + 1))
+        val piece: PieceViewModel = boardState[position] as PieceViewModel
+        selectedPieceViewModel.postValue(piece)
+        return when(piece.pieceType) {
+            PieceType.PAWN -> {
+                PieceMovementRules.pawnAvailableMovement(position)
+            }
+            else -> {
+                listOf(position.copy(x = position.x + 1))
+            }
+        }
     }
 
     private fun initialPiecesSetup(): Map<Position, PieceViewModel> {

--- a/app/src/main/java/com/projectthrive/chess/ui/main/GameEngine.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/GameEngine.kt
@@ -1,6 +1,6 @@
 package com.projectthrive.chess.ui.main
 
-import com.projectthrive.chess.ui.main.GameViewModel.Companion.selectedPieceViewModel
+import com.projectthrive.chess.ui.main.GameViewModel.Companion.selectedSpot
 
 class GameEngine {
     private val boardState = mutableMapOf<Position, PieceViewModel>()
@@ -11,20 +11,42 @@ class GameEngine {
 
     fun initialPieces() = boardState.toMap()
 
+    fun getBoardState() = boardState
+
     fun getHighlightedPositions(position: Position): List<Position> {
         if (boardState[position] == null) {
-            selectedPieceViewModel.postValue(null)
+            selectedSpot.postValue(null)
             return emptyList()
         }
 
         val piece: PieceViewModel = boardState[position] as PieceViewModel
-        selectedPieceViewModel.postValue(piece)
+        selectedSpot.postValue(Pair(position, piece))
         return when(piece.pieceType) {
             PieceType.PAWN -> {
-                PieceMovementRules.pawnAvailableMovement(position)
+                PieceMovementRules.pawnAvailableMovement(boardState, position, piece.color)
             }
             else -> {
                 listOf(position.copy(x = position.x + 1))
+            }
+        }
+    }
+
+    fun tryMove(pieceViewModel: PieceViewModel, from: Position, to: Position) {
+        when(pieceViewModel.pieceType) {
+            PieceType.PAWN -> {
+                val validMoves = PieceMovementRules.pawnAvailableMovement(
+                        boardState,
+                        from,
+                        pieceViewModel.color
+                ).toSet()
+
+                if (validMoves.contains(to)) {
+                    boardState.remove(from)
+                    boardState[to] = pieceViewModel
+                    selectedSpot.postValue(null)
+                 } else {
+                    selectedSpot.postValue(null)
+                }
             }
         }
     }

--- a/app/src/main/java/com/projectthrive/chess/ui/main/GameEngine.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/GameEngine.kt
@@ -4,14 +4,16 @@ import com.projectthrive.chess.ui.main.GameViewModel.Companion.selectedSpot
 
 class GameEngine {
     private val boardState = mutableMapOf<Position, PieceViewModel>()
+    private val pieceMovementRules: PieceMovementRules = PieceMovementRules()
 
     init {
         boardState.putAll(initialPiecesSetup())
+        pieceMovementRules.initialPawnsPositions.addAll(boardState.filter { it.value.pieceType == PieceType.PAWN }.keys)
     }
 
     fun initialPieces() = boardState.toMap()
 
-    fun getBoardState() = boardState
+    fun getBoardState() = boardState.toMap()
 
     fun getHighlightedPositions(position: Position): List<Position> {
         if (boardState[position] == null) {
@@ -23,7 +25,7 @@ class GameEngine {
         selectedSpot.postValue(Pair(position, piece))
         return when(piece.pieceType) {
             PieceType.PAWN -> {
-                PieceMovementRules.pawnAvailableMovement(boardState, position, piece.color)
+                pieceMovementRules.pawnAvailableMovement(boardState, position, piece.color)
             }
             else -> {
                 listOf(position.copy(x = position.x + 1))
@@ -34,7 +36,7 @@ class GameEngine {
     fun tryMove(pieceViewModel: PieceViewModel, from: Position, to: Position) {
         when(pieceViewModel.pieceType) {
             PieceType.PAWN -> {
-                val validMoves = PieceMovementRules.pawnAvailableMovement(
+                val validMoves = pieceMovementRules.pawnAvailableMovement(
                         boardState,
                         from,
                         pieceViewModel.color
@@ -44,7 +46,7 @@ class GameEngine {
                     boardState.remove(from)
                     boardState[to] = pieceViewModel
                     selectedSpot.postValue(null)
-                 } else {
+                } else {
                     selectedSpot.postValue(null)
                 }
             }

--- a/app/src/main/java/com/projectthrive/chess/ui/main/GameEngine.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/GameEngine.kt
@@ -1,7 +1,5 @@
 package com.projectthrive.chess.ui.main
 
-import com.projectthrive.chess.ui.main.GameViewModel.Companion.selectedSpot
-
 class GameEngine {
     private val boardState = mutableMapOf<Position, PieceViewModel>()
     private val pieceMovementRules: PieceMovementRules = PieceMovementRules()
@@ -13,16 +11,12 @@ class GameEngine {
 
     fun initialPieces() = boardState.toMap()
 
-    fun getBoardState() = boardState.toMap()
-
     fun getHighlightedPositions(position: Position): List<Position> {
         if (boardState[position] == null) {
-            selectedSpot.postValue(null)
             return emptyList()
         }
 
         val piece: PieceViewModel = boardState[position] as PieceViewModel
-        selectedSpot.postValue(Pair(position, piece))
         return when(piece.pieceType) {
             PieceType.PAWN -> {
                 pieceMovementRules.pawnAvailableMovement(boardState, position, piece.color)
@@ -33,24 +27,25 @@ class GameEngine {
         }
     }
 
-    fun tryMove(pieceViewModel: PieceViewModel, from: Position, to: Position) {
-        when(pieceViewModel.pieceType) {
+    fun tryMove(from: Position, to: Position) : Map<Position, PieceViewModel>  {
+        val pieceViewModel = boardState[from]
+
+        when (pieceViewModel?.pieceType) {
             PieceType.PAWN -> {
                 val validMoves = pieceMovementRules.pawnAvailableMovement(
-                        boardState,
-                        from,
-                        pieceViewModel.color
+                    boardState,
+                    from,
+                    pieceViewModel.color
                 ).toSet()
 
                 if (validMoves.contains(to)) {
                     boardState.remove(from)
                     boardState[to] = pieceViewModel
-                    selectedSpot.postValue(null)
-                } else {
-                    selectedSpot.postValue(null)
                 }
             }
         }
+
+        return boardState.toMap()
     }
 
     private fun initialPiecesSetup(): Map<Position, PieceViewModel> {

--- a/app/src/main/java/com/projectthrive/chess/ui/main/GameViewModel.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/GameViewModel.kt
@@ -6,7 +6,12 @@ import androidx.lifecycle.ViewModel
 class GameViewModel : ViewModel() {
 
     private val gameEngine: GameEngine
-    val boardLiveData = MutableLiveData<BoardViewModel>()
+
+    companion object {
+        val boardLiveData = MutableLiveData<BoardViewModel>()
+        val selectedPieceViewModel = MutableLiveData<PieceViewModel>(null)
+    }
+
 
     init {
         gameEngine = GameEngine()

--- a/app/src/main/java/com/projectthrive/chess/ui/main/GameViewModel.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/GameViewModel.kt
@@ -7,11 +7,7 @@ class GameViewModel : ViewModel() {
 
     private val gameEngine: GameEngine
     val boardLiveData = MutableLiveData<BoardViewModel>()
-
-    companion object {
-        val selectedSpot = MutableLiveData<Pair<Position,PieceViewModel>>(null)
-    }
-
+    var selectedTile: Position? = null
 
     init {
         gameEngine = GameEngine()
@@ -22,23 +18,40 @@ class GameViewModel : ViewModel() {
 
     fun onPieceClicked(position: Position) {
         boardLiveData.value?.let {
-            val selectedSquare = selectedSpot.value
-            val selectedPiecePosition = selectedSquare?.first
-            if (selectedPiecePosition != null) {
-                val selectedPiece = selectedSquare.second
-                gameEngine.tryMove(selectedPiece, selectedPiecePosition, position)
-                boardLiveData.postValue(
-                        it.copy(
-                                pieces = gameEngine.getBoardState(),
-                                highlightedPositions = emptyList()
-                        )
-                )
+            val currentSelectedTile = selectedTile
+
+            if (currentSelectedTile != null) {
+                tryToMovePiece(it, currentSelectedTile, position)
             } else {
-                boardLiveData.postValue(
-                        it.copy(highlightedPositions = gameEngine.getHighlightedPositions(position))
-                )
+                getHighlightedPosition(it, position)
             }
         }
+    }
+
+    private fun tryToMovePiece(
+        boardViewModel: BoardViewModel,
+        currentSelectedTile : Position,
+        position: Position
+    ) {
+        val pieces = gameEngine.tryMove(currentSelectedTile, position)
+        selectedTile = null
+
+        boardLiveData.postValue(
+            boardViewModel.copy(
+                pieces = pieces,
+                highlightedPositions = emptyList()
+            )
+        )
+    }
+
+    private fun getHighlightedPosition(
+        it: BoardViewModel,
+        position: Position
+    ) {
+        selectedTile = position
+        boardLiveData.postValue(
+            it.copy(highlightedPositions = gameEngine.getHighlightedPositions(position))
+        )
     }
 }
 

--- a/app/src/main/java/com/projectthrive/chess/ui/main/GameViewModel.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/GameViewModel.kt
@@ -6,10 +6,10 @@ import androidx.lifecycle.ViewModel
 class GameViewModel : ViewModel() {
 
     private val gameEngine: GameEngine
+    val boardLiveData = MutableLiveData<BoardViewModel>()
 
     companion object {
-        val boardLiveData = MutableLiveData<BoardViewModel>()
-        val selectedPieceViewModel = MutableLiveData<PieceViewModel>(null)
+        val selectedSpot = MutableLiveData<Pair<Position,PieceViewModel>>(null)
     }
 
 
@@ -22,9 +22,22 @@ class GameViewModel : ViewModel() {
 
     fun onPieceClicked(position: Position) {
         boardLiveData.value?.let {
-            boardLiveData.postValue(
-                it.copy(highlightedPositions = gameEngine.getHighlightedPositions(position))
-            )
+            val selectedSquare = selectedSpot.value
+            val selectedPiecePosition = selectedSquare?.first
+            if (selectedPiecePosition != null) {
+                val selectedPiece = selectedSquare.second
+                gameEngine.tryMove(selectedPiece, selectedPiecePosition, position)
+                boardLiveData.postValue(
+                        it.copy(
+                                pieces = gameEngine.getBoardState(),
+                                highlightedPositions = emptyList()
+                        )
+                )
+            } else {
+                boardLiveData.postValue(
+                        it.copy(highlightedPositions = gameEngine.getHighlightedPositions(position))
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/projectthrive/chess/ui/main/PieceMovementRules.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/PieceMovementRules.kt
@@ -1,66 +1,69 @@
 package com.projectthrive.chess.ui.main
 
-class PieceMovementRules {
-    companion object {
-        fun pawnAvailableMovement(
-                boardState: Map<Position,PieceViewModel>, 
-                position: Position, 
-                pieceColor: PieceColor
-        ): List<Position> {
-            
-            val validMoves = mutableListOf<Position>()
-            if (pieceColor == PieceColor.WHITE){
-                when {
-                    boardState[Position(position.x + 2, position.y)] != null -> {
-                        validMoves.add(Position(position.x + 1, position.y))
-                    }
-                    boardState[Position(position.x + 1, position.y)] == null -> {
+class PieceMovementRules() {
+    val initialPawnsPositions = mutableSetOf<Position>()
+
+    fun pawnAvailableMovement(
+            boardState: Map<Position,PieceViewModel>,
+            position: Position,
+            pieceColor: PieceColor
+    ): List<Position> {
+
+        val validMoves = mutableListOf<Position>()
+        if (pieceColor == PieceColor.WHITE){
+            when {
+                boardState[Position(position.x + 2, position.y)] != null -> {
+                    validMoves.add(Position(position.x + 1, position.y))
+                }
+                boardState[Position(position.x + 1, position.y)] == null -> {
+                    if (initialPawnsPositions.contains(position)) {
                         validMoves.add(Position(position.x + 1, position.y))
                         validMoves.add(Position(position.x + 2, position.y))
-                    }
-                }
-
-                boardState[Position(position.x + 1, position.y + 1)]?.let {
-                    if (it.color != pieceColor) {
-                        validMoves.add(Position(position.x + 1, position.y + 1))
-                    }
-                }
-
-                boardState[Position(position.x + 1, position.y - 1)]?.let {
-                    if (it.color != pieceColor) {
-                        validMoves.add(Position(position.x + 1, position.y - 1))
-                    }
-                }
-            } else {
-                when {
-                    boardState[Position(position.x - 2, position.y)] != null -> {
-                        validMoves.add(Position(position.x - 1, position.y))
-                    }
-                    boardState[Position(position.x - 1, position.y)] == null -> {
-                        validMoves.add(Position(position.x - 1, position.y))
-                        validMoves.add(Position(position.x - 2, position.y))
-                    }
-                }
-
-                boardState[Position(position.x - 1, position.y - 1)]?.let {
-                    if (it.color != pieceColor) {
-                        validMoves.add(Position(position.x - 1, position.y - 1))
-                    }
-                }
-
-                boardState[Position(position.x - 1, position.y + 1)]?.let {
-                    if (it.color != pieceColor) {
-                        validMoves.add(Position(position.x - 1, position.y + 1))
+                    } else {
+                        validMoves.add(Position(position.x + 1, position.y))
                     }
                 }
             }
-//            if (isMadeFirstMove) {
-//                
-//            } else {
-//                if (color == PieceColor.WHITE){ validMoves.add(Position(position.x, position.y + 1)) }
-//                else { validMoves.add(Position(position.x, position.y - 1)) }
-//            }
-            return validMoves.toList()
+
+            boardState[Position(position.x + 1, position.y + 1)]?.let {
+                if (it.color != pieceColor) {
+                    validMoves.add(Position(position.x + 1, position.y + 1))
+                }
+            }
+
+            boardState[Position(position.x + 1, position.y - 1)]?.let {
+                if (it.color != pieceColor) {
+                    validMoves.add(Position(position.x + 1, position.y - 1))
+                }
+            }
+        } else {
+            when {
+                boardState[Position(position.x - 2, position.y)] != null -> {
+                    validMoves.add(Position(position.x - 1, position.y))
+                }
+                boardState[Position(position.x - 1, position.y)] == null -> {
+                    if (initialPawnsPositions.contains(position)) {
+                        validMoves.add(Position(position.x - 1, position.y))
+                        validMoves.add(Position(position.x - 2, position.y))
+                    } else {
+                        validMoves.add(Position(position.x - 1, position.y))
+                    }
+                }
+            }
+
+            boardState[Position(position.x - 1, position.y - 1)]?.let {
+                if (it.color != pieceColor) {
+                    validMoves.add(Position(position.x - 1, position.y - 1))
+                }
+            }
+
+            boardState[Position(position.x - 1, position.y + 1)]?.let {
+                if (it.color != pieceColor) {
+                    validMoves.add(Position(position.x - 1, position.y + 1))
+                }
+            }
         }
+        return validMoves.toList()
     }
+
 }

--- a/app/src/main/java/com/projectthrive/chess/ui/main/PieceMovementRules.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/PieceMovementRules.kt
@@ -2,8 +2,43 @@ package com.projectthrive.chess.ui.main
 
 class PieceMovementRules {
     companion object {
-        fun pawnAvailableMovement(position: Position): List<Position> {
-            return emptyList()
+        fun pawnAvailableMovement(
+                boardState: Map<Position,PieceViewModel>, 
+                position: Position, 
+                pieceColor: PieceColor
+        ): List<Position> {
+            
+            val validMoves = mutableListOf<Position>()
+            if (pieceColor == PieceColor.WHITE){
+                when {
+                    boardState[Position(position.x + 1, position.y)] != null -> return emptyList()
+                    boardState[Position(position.x + 2, position.y)] != null -> {
+                        validMoves.add(Position(position.x + 1, position.y))
+                    }
+                    else -> {
+                        validMoves.add(Position(position.x + 1, position.y))
+                        validMoves.add(Position(position.x + 2, position.y))
+                    }
+                }
+            } else {
+                when {
+                    boardState[Position(position.x - 1, position.y)] != null -> return emptyList()
+                    boardState[Position(position.x - 2, position.y)] != null -> {
+                        validMoves.add(Position(position.x - 1, position.y))
+                    }
+                    else -> {
+                        validMoves.add(Position(position.x - 1, position.y))
+                        validMoves.add(Position(position.x - 2, position.y))
+                    }
+                }
+            }
+//            if (isMadeFirstMove) {
+//                
+//            } else {
+//                if (color == PieceColor.WHITE){ validMoves.add(Position(position.x, position.y + 1)) }
+//                else { validMoves.add(Position(position.x, position.y - 1)) }
+//            }
+            return validMoves.toList()
         }
     }
 }

--- a/app/src/main/java/com/projectthrive/chess/ui/main/PieceMovementRules.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/PieceMovementRules.kt
@@ -1,0 +1,9 @@
+package com.projectthrive.chess.ui.main
+
+class PieceMovementRules {
+    companion object {
+        fun pawnAvailableMovement(position: Position): List<Position> {
+            return emptyList()
+        }
+    }
+}

--- a/app/src/main/java/com/projectthrive/chess/ui/main/PieceMovementRules.kt
+++ b/app/src/main/java/com/projectthrive/chess/ui/main/PieceMovementRules.kt
@@ -11,24 +11,46 @@ class PieceMovementRules {
             val validMoves = mutableListOf<Position>()
             if (pieceColor == PieceColor.WHITE){
                 when {
-                    boardState[Position(position.x + 1, position.y)] != null -> return emptyList()
                     boardState[Position(position.x + 2, position.y)] != null -> {
                         validMoves.add(Position(position.x + 1, position.y))
                     }
-                    else -> {
+                    boardState[Position(position.x + 1, position.y)] == null -> {
                         validMoves.add(Position(position.x + 1, position.y))
                         validMoves.add(Position(position.x + 2, position.y))
                     }
                 }
+
+                boardState[Position(position.x + 1, position.y + 1)]?.let {
+                    if (it.color != pieceColor) {
+                        validMoves.add(Position(position.x + 1, position.y + 1))
+                    }
+                }
+
+                boardState[Position(position.x + 1, position.y - 1)]?.let {
+                    if (it.color != pieceColor) {
+                        validMoves.add(Position(position.x + 1, position.y - 1))
+                    }
+                }
             } else {
                 when {
-                    boardState[Position(position.x - 1, position.y)] != null -> return emptyList()
                     boardState[Position(position.x - 2, position.y)] != null -> {
                         validMoves.add(Position(position.x - 1, position.y))
                     }
-                    else -> {
+                    boardState[Position(position.x - 1, position.y)] == null -> {
                         validMoves.add(Position(position.x - 1, position.y))
                         validMoves.add(Position(position.x - 2, position.y))
+                    }
+                }
+
+                boardState[Position(position.x - 1, position.y - 1)]?.let {
+                    if (it.color != pieceColor) {
+                        validMoves.add(Position(position.x - 1, position.y - 1))
+                    }
+                }
+
+                boardState[Position(position.x - 1, position.y + 1)]?.let {
+                    if (it.color != pieceColor) {
+                        validMoves.add(Position(position.x - 1, position.y + 1))
                     }
                 }
             }


### PR DESCRIPTION
The pawns can now move forward twice on their initial move and once after that.
They can also attack pieces on their attack squares as long as they are not of the same color.

The special moves have not been implemented yet. 
- Enpassant; and
- Promotion.